### PR TITLE
update FSharp.Data, fix WorldBank example, fix a few typos

### DIFF
--- a/Dojo/Script.fsx
+++ b/Dojo/Script.fsx
@@ -108,7 +108,7 @@ let lib = Lib.GetSample()
 //
 // Use CsvProvider to load the Titanic data set from "data/Titanic.csv"
 // (using the default column separator) and find the name of a female
-// passenger who was 19 years old and embarked in the prot marked "Q"
+// passenger who was 19 years old and embarked in the port marked "Q"
 // Then return Substring(19, 3) from her name.
 // ------------------------------------------------------------------
 

--- a/Dojo/Script.fsx
+++ b/Dojo/Script.fsx
@@ -14,7 +14,7 @@ open FSharp.Data
 // Create connection to the WorldBank service
 let wb = WorldBankData.GetDataContext()
 // Get specific indicator for a specific country at a given year
-wb.Countries.``Czech Republic``.Indicators.``Population ages 0-14 (% of total)``.[2000]
+wb.Countries.``Czech Republic``.Indicators.``Population, ages 0-14 (% of total)``.[2000]
 // Get a list of countries in a specified region
 for c in wb.Regions.``Euro area``.Countries do
   printfn "%s" c.Name

--- a/Dojo/Script.fsx
+++ b/Dojo/Script.fsx
@@ -1,5 +1,5 @@
 ﻿#r "System.Xml.Linq.dll"
-#r "packages/FSharp.Data.2.2.2/lib/net40/FSharp.Data.dll"
+#r "packages/FSharp.Data.2.2.5/lib/net40/FSharp.Data.dll"
 open FSharp.Data
 
 // ------------------------------------------------------------------

--- a/Dojo/packages.config
+++ b/Dojo/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Data" version="2.2.2" targetFramework="net45" />
+  <package id="FSharp.Data" version="2.2.5" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ in about 1 hour. With more time, each group can find multiple words.
 
 ## Building and running the sample
 
-The sampe solution uses NuGet restore to get the `FSharp.Data.dll` automatically. Open `TypeProviders-Dojo.sln` and 
+The sample solution uses NuGet restore to get the `FSharp.Data.dll` automatically. Open `TypeProviders-Dojo.sln` and 
 Build the solution once - this will download F# Data into `packages` folder and you can then open `Script.fsx` and 
 go through the script in F# Interactive (the build is only needed to restore the packages).
 


### PR DESCRIPTION
I ran through the dojo tonight in preparation for delivering it at our local user group. I was unable to get the `bbc.xml` to parse with 2.2.2, but 2.2.5 seems to work. Also, there was a little change required to get the World Bank sample to work. Other than that there were a few typos. I'm on a Mac, and I didn't elide the end of file changes in my commits. I hope that's ok. This is going to be a fun dojo! Thanks!